### PR TITLE
Modify backend to use the COOL Terraform account

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ module "example" {
     Key2 = "Value2"
   }
   terraform_role_arn         = "arn:aws:iam::123456789012:role/TerraformRole"
-  trusted_cidr_blocks        = [
-    "66.66.66.0/24",
-    "108.108.108.108/32"
-  ]
   vpc_cidr_block             = "10.10.0.0/16"
 }
 ```
@@ -38,7 +34,6 @@ module "example" {
 | public_subnet_cidr_blocks | The CIDR blocks corresponding to the public subnets to be associated with the VPC (e.g. ["10.10.0.0/24", "10.10.1.0/24"]).  These must be /24 blocks, since we are using them to create reverse DNS zones. | list(string) | | yes |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
 | terraform_role_arn | The ARN of the role to assume when creating, modifying, or destroying resources via Terraform. | string | | yes |
-| trusted_cidr_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. ["10.10.0.0/16", "10.11.0.0/16"]). | list(string) | `[]` | no |
 | vpc_cidr_block | The overall CIDR block to be associated with the VPC (e.g. "10.10.0.0/16"). | string | | yes |
 
 ## Outputs ##

--- a/backend.tf
+++ b/backend.tf
@@ -3,7 +3,7 @@ terraform {
     encrypt        = true
     bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
-    role_arn       = "arn:aws:iam::608004238745:role/TerraformStateAccess"
+    profile        = "terraform-role"
     region         = "us-east-1"
     key            = "cool-shared-services-networking/terraform.tfstate"
   }

--- a/backend.tf
+++ b/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
     encrypt        = true
-    bucket         = "playground-terraform-state-storage"
+    bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
-    profile        = "playground"
+    role_arn       = "arn:aws:iam::608004238745:role/TerraformStateAccess"
     region         = "us-east-1"
     key            = "cool-shared-services-networking/terraform.tfstate"
   }

--- a/route53_zones.tf
+++ b/route53_zones.tf
@@ -3,7 +3,7 @@
 #-------------------------------------------------------------------------------
 resource "aws_route53_zone" "private_zone" {
   name = var.cool_domain
-
+  tags = var.tags
   vpc {
     vpc_id = aws_vpc.the_vpc.id
   }

--- a/variables.tf
+++ b/variables.tf
@@ -43,9 +43,3 @@ variable "tags" {
   description = "Tags to apply to all AWS resources created."
   default     = {}
 }
-
-variable "trusted_cidr_blocks" {
-  type        = list(string)
-  description = "A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
-  default     = []
-}


### PR DESCRIPTION
## 🗣 Description

This pull request modifies the backend configuration to use the COOL Terraform account instead of the playground account for state storage and locking.

## 💭 Motivation and Context

We should use the COOL accounts for everything.

## 🧪 Testing

I was able to deploy to the COOL using these backend changes, and all the pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
