### PR TITLE
Simplify depends_on usage

### DIFF
--- a/route53_zones.tf
+++ b/route53_zones.tf
@@ -1,12 +1,11 @@
 #-------------------------------------------------------------------------------
 # Create a private Route53 zone for the VPC.
-#-------------------------------------------------------------------------------
+#
+# Note that all these resources depend on the VPC, and hence on the
+# aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
+# resource.
+# -------------------------------------------------------------------------------
 resource "aws_route53_zone" "private_zone" {
-  # We can't perform this action until our policy is in place.
-  depends_on = [
-    aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
-  ]
-
   name = var.cool_domain
   tags = var.tags
   vpc {
@@ -18,10 +17,6 @@ resource "aws_route53_zone" "private_zone" {
 # Create private Route53 reverse zones for the VPC subnets.
 #-------------------------------------------------------------------------------
 resource "aws_route53_zone" "private_subnet_private_reverse_zones" {
-  # We can't perform this action until our policy is in place.
-  depends_on = [
-    aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
-  ]
   for_each = toset(var.private_subnet_cidr_blocks)
 
   # Note that this code assumes that we are using /24 blocks.
@@ -38,10 +33,6 @@ resource "aws_route53_zone" "private_subnet_private_reverse_zones" {
 }
 
 resource "aws_route53_zone" "public_subnet_private_reverse_zones" {
-  # We can't perform this action until our policy is in place.
-  depends_on = [
-    aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
-  ]
   for_each = toset(var.public_subnet_cidr_blocks)
 
   # Note that this code assumes that we are using /24 blocks.

--- a/vpc.tf
+++ b/vpc.tf
@@ -2,7 +2,11 @@
 # Create the shared services VPC.
 #-------------------------------------------------------------------------------
 resource "aws_vpc" "the_vpc" {
-  # We can't perform this action until our policy is in place.
+  # We can't perform this action until our policy is in place, so we
+  # need this dependency.  Since the other resources in this file
+  # directly or indirectly depend on the VPC, making the VPC depend on
+  # this resource should make the other resources in this file depend
+  # on it as well.
   depends_on = [
     aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
   ]
@@ -18,33 +22,18 @@ resource "aws_vpc" "the_vpc" {
 
 # The internet gateway for the VPC
 resource "aws_internet_gateway" "the_igw" {
-  # We can't perform this action until our policy is in place.
-  depends_on = [
-    aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
-  ]
-
   vpc_id = aws_vpc.the_vpc.id
   tags   = var.tags
 }
 
 # Default route table
 resource "aws_default_route_table" "the_route_table" {
-  # We can't perform this action until our policy is in place.
-  depends_on = [
-    aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
-  ]
-
   default_route_table_id = aws_vpc.the_vpc.default_route_table_id
   tags                   = var.tags
 }
 
 # Route all external traffic through the internet gateway
 resource "aws_route" "route_external_traffic_through_internet_gateway" {
-  # We can't perform this action until our policy is in place.
-  depends_on = [
-    aws_iam_role_policy_attachment.provisionnetworking_policy_attachment
-  ]
-
   route_table_id         = aws_default_route_table.the_route_table.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.the_igw.id


### PR DESCRIPTION
## 🗣 Description

If resource A depends on resource B, and resource B has an explicit `depends_on` for resource C, then resource A does not need an explicit `depends_on` for resource C.

## 💭 Motivation and Context

This simplifies the code and the dependency graph that Terraform works with.

## 🧪 Testing

I ran a `terraform deploy` and verified that Terraform did not want to make any changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
