### PR TITLE
Use the new OrganizationsReadOnly role to determine accounts to invite to join the Transit Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ At this point the `ProvisionNetworking` policy is attached to the
 | provisionnetworking_policy_description | The description to associate with the IAM policy that allows provisioning of the networking layer in the Shared Services account. | string | `Allows provisioning of the networking layer in the Shared Services account.` | no |
 | provisionnetworking_policy_name | The name to associate with the IAM policy that allows provisioning of the networking layer in the Shared Services account. | string | `ProvisionNetworking` | no |
 | public_subnet_cidr_blocks | The CIDR blocks corresponding to the public subnets to be associated with the VPC (e.g. ["10.10.0.0/24", "10.10.1.0/24"]).  These must be /24 blocks, since we are using them to create reverse DNS zones. | list(string) | | yes |
-| transit_gateway_account_ids | A map of account names and IDs that are allowed to use the Transit Gateway in the Shared Services account for cross-VPC communication. | map(string) | `{}` | no |
 | transit_gateway_description | The description to associate with the Transit Gateway in the Shared Services account that allows cross-VPC communication. | string | `The Transit Gateway in the Shared Services account that allows cross-VPC communication.` | no |
 | tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
 | vpc_cidr_block | The overall CIDR block to be associated with the VPC (e.g. "10.10.0.0/16"). | string | | yes |

--- a/providers.tf
+++ b/providers.tf
@@ -2,3 +2,9 @@ provider "aws" {
   profile = "cool-sharedservices-provisionaccount"
   region  = var.aws_region
 }
+
+provider "aws" {
+  alias   = "organizationsreadonly"
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -36,11 +36,10 @@ resource "aws_ram_resource_association" "tgw" {
 }
 
 # Share the resource with the other accounts that are allowed to
-# access it
+# access it (currently the env* accounts)
 data "aws_organizations_organization" "cool" {
   provider = aws.organizationsreadonly
 }
-
 resource "aws_ram_principal_association" "tgw" {
   for_each = { for account in data.aws_organizations_organization.cool.accounts : account.name => account.id if substr(account.name, 0, 3) == "env" }
 

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -37,8 +37,12 @@ resource "aws_ram_resource_association" "tgw" {
 
 # Share the resource with the other accounts that are allowed to
 # access it
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
 resource "aws_ram_principal_association" "tgw" {
-  for_each = var.transit_gateway_account_ids
+  for_each = { for account in data.aws_organizations_organization.cool.accounts : account.name => account.id if substr(account.name, 0, 3) == "env" }
 
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.tgw.id

--- a/variables.tf
+++ b/variables.tf
@@ -58,12 +58,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "transit_gateway_account_ids" {
-  type        = map(string)
-  description = "A map of account names and IDs that are allowed to use the Transit Gateway in the Shared Services account for cross-VPC communication."
-  default     = {}
-}
-
 variable "transit_gateway_description" {
   description = "The description to associate with the Transit Gateway in the Shared Services account that allows cross-VPC communication."
   default     = "The Transit Gateway in the Shared Services account that allows cross-VPC communication."


### PR DESCRIPTION
## 🗣 Description

In this pull request I make use of the new OrganizationsReadOnly role in the Master account (created in cisagov/cool-accounts#23) to dynamically determine which organization accounts to invite to join the Transit Gateway.

## 💭 Motivation and Context

Why specify via an input what you can automagically determine dynamically?

## 🧪 Testing

I deployed these changes to production and verified that Terraform did not want to make any changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
