### PR TITLE
Add routing tables as outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ At this point the `ProvisionNetworking` policy is attached to the
 
 | Name | Description |
 |------|-------------|
+| default_route_table | The default route table for the VPC, which is used by the public subnets. |
+| private_route_tables | The route tables used by the private subnets in the VPC. |
 | private_subnets | The private subnets in the VPC. |
 | private_subnet_nat_gws | The NAT gateways used in the private subnets in the VPC. |
 | private_subnet_private_reverse_zones | The private Route53 reverse zones for the private subnets in the VPC. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,13 @@
+output "default_route_table" {
+  value       = aws_default_route_table.public
+  description = "The default route table for the VPC, which is used by the public subnets."
+}
+
+output "private_route_tables" {
+  value       = aws_route_table.private_route_tables
+  description = "The route tables used by the private subnets in the VPC."
+}
+
 output "private_subnets" {
   value       = module.private.subnets
   description = "The private subnets in the VPC."

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "private_subnets" {
 
 output "private_subnet_nat_gws" {
   value       = aws_nat_gateway.nat_gws
-  description = "The the NAT gateways used in the private subnets in the VPC."
+  description = "The NAT gateways used in the private subnets in the VPC."
 }
 
 output "private_subnet_private_reverse_zones" {


### PR DESCRIPTION
## 🗣 Description

Add the VPC routing tables as outputs.

## 💭 Motivation and Context

This is required because, in order to resolve cisagov/cool-sharedservices-networking#11, we need to add a route to each routing table.  We can't do that here because we don't yet have the OpenVPN server's instance ID, so we have to do it in [cisagov/cool-sharedservices-networking](https://github.com/cisagov/cool-sharedservices-networking).

## 🧪 Testing

All pre-commit hooks pass.  These changes are not yet deployed to production.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
