### PR TITLE
Specify the string type for variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,10 +5,12 @@
 # ------------------------------------------------------------------------------
 
 variable "cool_cidr_block" {
+  type        = string
   description = "The overall CIDR block associated with the COOL (e.g. \"10.128.0.0/9\")."
 }
 
 variable "cool_domain" {
+  type        = string
   description = "The domain where the COOL resources reside (e.g. \"cool.cyber.dhs.gov\")."
 }
 
@@ -23,6 +25,7 @@ variable "public_subnet_cidr_blocks" {
 }
 
 variable "vpc_cidr_block" {
+  type        = string
   description = "The overall CIDR block to be associated with the VPC (e.g. \"10.10.0.0/16\")."
 }
 
@@ -33,21 +36,25 @@ variable "vpc_cidr_block" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the shared services account is to be created (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "provisionaccount_role_name" {
+  type        = string
   description = "The name of the IAM role that allows sufficient permissions to provision all AWS resources in the Shared Services account."
   default     = "ProvisionAccount"
 }
 
 variable "provisionnetworking_policy_description" {
+  type        = string
   description = "The description to associate with the IAM policy that allows provisioning of the networking layer in the Shared Services account."
   default     = "Allows provisioning of the networking layer in the Shared Services account."
 }
 
 variable "provisionnetworking_policy_name" {
+  type        = string
   description = "The name to assign the IAM policy that allows provisioning of the networking layer in the Shared Services account."
   default     = "ProvisionNetworking"
 }
@@ -59,6 +66,7 @@ variable "tags" {
 }
 
 variable "transit_gateway_description" {
+  type        = string
   description = "The description to associate with the Transit Gateway in the Shared Services account that allows cross-VPC communication."
   default     = "The Transit Gateway in the Shared Services account that allows cross-VPC communication."
 }


### PR DESCRIPTION
## 🗣 Description

Previously string was the default type, but this is [no longer the case](https://www.terraform.io/docs/configuration/variables.html#type-constraints).

I ran into a case today where this mattered.  I used `set([var.string_value])` in a `for_each`, and Terraform rejected the syntax since it couldn't verify that the output would be a set of strings.  Adding the string type declaration to the variable fixed the issue.

## 💭 Motivation and Context

This change makes the code more correct, and it will avoid subtle errors like the one I saw today.

## 🧪 Testing

I ran a `terraform apply` and verified that nothing needed to be changed.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
