### PR TITLE
Allow zone association with multiple VPCs

### DIFF
--- a/route53_zones.tf
+++ b/route53_zones.tf
@@ -6,6 +6,10 @@
 # resource.
 # -------------------------------------------------------------------------------
 resource "aws_route53_zone" "private_zone" {
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+
   name = var.cool_domain
   tags = var.tags
   vpc {
@@ -18,6 +22,9 @@ resource "aws_route53_zone" "private_zone" {
 #-------------------------------------------------------------------------------
 resource "aws_route53_zone" "private_subnet_private_reverse_zones" {
   for_each = toset(var.private_subnet_cidr_blocks)
+  lifecycle {
+    ignore_changes = [vpc]
+  }
 
   # Note that this code assumes that we are using /24 blocks.
   name = format(
@@ -34,6 +41,9 @@ resource "aws_route53_zone" "private_subnet_private_reverse_zones" {
 
 resource "aws_route53_zone" "public_subnet_private_reverse_zones" {
   for_each = toset(var.public_subnet_cidr_blocks)
+  lifecycle {
+    ignore_changes = [vpc]
+  }
 
   # Note that this code assumes that we are using /24 blocks.
   name = format(


### PR DESCRIPTION
## 🗣 Description

Allow private zone to be associated with multiple VPCs.

## 💭 Motivation and Context

Private zones *must always* be associated with a VPC, so I must use inline `vpc` blocks when defining these zones.  Other VPCs may want to associate with these zones as well (particularly the private zone - for DNS purposes), though, and they will have to use a standalone `aws_route53_zone_association` to do so.  Mixing inline and standalone resources like this leads to a flapping of Terraform state, and the only cure is to ignore changes to `vpc`.  Therefore I have to define these `lifecycle` blocks.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
