### PR TITLE
Use separate Transit Gateway route tables for other TGW attachments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,25 @@ jobs:
       - uses: actions/setup-go@v2-beta
         with:
           go-version: '1.13.8'
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Cache curl downloads
         uses: actions/cache@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mypy_cache
 __pycache__
 .python-version
 .terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 | public_subnets | The public subnets in the VPC. |
 | public_subnet_private_reverse_zones | The private Route53 reverse zones for the public subnets in the VPC. |
 | transit_gateway | The Transit Gateway that allows cross-VPC communication. |
+| transit_gateway_attachment_route_tables | Transit Gateway route tables for each of the accounts that are allowed to attach to the Transit Gateway.  These route tables ensure that these accounts can communicate with the Shared Services account but are isolated from each other. |
 | transit_gateway_ram_resource | The RAM resource share associated with the Transit Gateway that allows cross-VPC communication. |
 | transit_gateway_principal_associations | The RAM resource principal associations for the Transit Gateway that allows cross-VPC communication. |
 | vpc | The shared services VPC. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,11 @@ output "transit_gateway" {
   description = "The Transit Gateway that allows cross-VPC communication."
 }
 
+output "transit_gateway_attachment_route_tables" {
+  value       = aws_ec2_transit_gateway_route_table.tgw_attachments
+  description = "Transit Gateway route tables for each of the accounts that are allowed to attach to the Transit Gateway.  These route tables ensure that these accounts can communicate with the Shared Services account but are isolated from each other."
+}
+
 output "transit_gateway_ram_resource" {
   value       = aws_ram_resource_association.tgw
   description = "The RAM resource share associated with the Transit Gateway that allows cross-VPC communication."

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -45,7 +45,7 @@ data "aws_organizations_organization" "cool" {
   provider = aws.organizationsreadonly
 }
 locals {
-  accounts = set([for account in data.aws_organizations_organization.cool.accounts : account.id if substr(account.name, 0, 3) == "env"])
+  accounts = toset([for account in data.aws_organizations_organization.cool.accounts : account.id if substr(account.name, 0, 3) == "env"])
 }
 resource "aws_ram_principal_association" "tgw" {
   for_each = local.accounts

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -72,7 +72,7 @@ resource "aws_ec2_transit_gateway_route" "sharedservices_routes" {
 
   destination_cidr_block         = aws_vpc.the_vpc.cidr_block
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.tgw.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.tgw_attachments.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.tgw_attachments[each.value].id
 }
 # The routes to the individual accounts are added at the time of
 # attachment.  The TGW attachment ID and CIDR block are required, and


### PR DESCRIPTION
## 🗣 Description

In this PR I modify the Terraform code to use a Transit Gateway route table different from the default one for all non-Shared Services Transit Gateway attachments.  This route table only allows traffic between the assessment VPC and the Shared Services VPC.

## 💭 Motivation and Context

We want assessment environments to be isolated from each other, and this is precisely what these changes achieve when combined with cisagov/cool-assessment-terraform#13.

## 🧪 Testing

All pre-commit hooks pass.  Once we have a COOL staging environment up and running then I can perform a real deployment test.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
