### PR TITLE
Add some permissions to the provisionnetworking policy

### DIFF
--- a/provisionnetworking_policy.tf
+++ b/provisionnetworking_policy.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "provisionnetworking_policy_doc" {
       "ec2:AllocateAddress",
       "ec2:AssociateRouteTable",
       "ec2:AttachInternetGateway",
+      "ec2:CreateFlowLogs",
       "ec2:CreateInternetGateway",
       "ec2:CreateNatGateway",
       "ec2:CreateNetworkAcl",
@@ -41,6 +42,7 @@ data "aws_iam_policy_document" "provisionnetworking_policy_doc" {
       "ec2:GetTransitGatewayRouteTablePropagations",
       "ec2:ModifyVpcAttribute",
       "ec2:ReleaseAddress",
+      "ec2:ReplaceRoute",
       "ec2:SearchTransitGatewayRoutes",
       "ram:AssociateResourceShare",
       "ram:CreateResourceShare",
@@ -84,6 +86,7 @@ data "aws_iam_policy_document" "provisionnetworking_policy_doc" {
 
     resources = [
       "arn:aws:logs:${var.aws_region}:${local.this_account_id}:log-group:vpc-flow-logs-sharedservices",
+      "arn:aws:logs:${var.aws_region}:${local.this_account_id}:log-group:vpc-flow-logs-sharedservices:log-stream:",
     ]
   }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request adds a few permissions to the provision policy.

## 💭 Motivation and Context

These permissions were found to be necessary when running `terraform apply` in our production environment this morning.  They are related to the creation of VPC flow logs and the replacement of routes in VPC route tables.

## 🧪 Testing

These changes were used to successfully apply the latest code to our production environment.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
