### PR TITLE
Make TGW support User Services account

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -59,6 +59,13 @@ locals {
     if length(regexall("PCA \\((${local.sharedservices_account_type})\\)", account.name)) > 0
   }
 
+  # Determine the User Services account of the same type
+  userservices_account_same_type = {
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id => account.name
+    if length(regexall("User Services \\((${local.sharedservices_account_type})\\)", account.name)) > 0
+  }
+
   # Find the Users account by name and email.
   users_account_id = [
     for x in data.aws_organizations_organization.cool.accounts :

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -61,12 +61,14 @@ resource "aws_ram_principal_association" "tgw" {
 # the Transit Gateway.  Each of these route tables only allows traffic
 # to flow between the shared services VPC and the account that is
 # allowed to attach to the Transit Gateway.  This way the accounts are
-# isolated from each other.
+# isolated from each other.  Note that certain accounts (e.g. Shared
+# Services and User Services) use the default TGW route table and are not
+# specifically mentioned below.
 #
 resource "aws_ec2_transit_gateway_route_table" "tgw_attachments" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
+  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
 
   transit_gateway_id = aws_ec2_transit_gateway.tgw.id
 }
@@ -74,7 +76,7 @@ resource "aws_ec2_transit_gateway_route_table" "tgw_attachments" {
 resource "aws_ec2_transit_gateway_route" "sharedservices_routes" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
+  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
 
   destination_cidr_block         = aws_vpc.the_vpc.cidr_block
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.tgw.id

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -45,12 +45,12 @@ resource "aws_ram_resource_association" "tgw" {
 
 #
 # Share the resource with the other accounts that are allowed to
-# access it (currently the env* and PCA accounts).
+# access it (currently the env*, PCA, and User Services accounts).
 #
 resource "aws_ram_principal_association" "tgw" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
+  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
 
   principal          = each.key
   resource_share_arn = aws_ram_resource_share.tgw.id
@@ -66,7 +66,7 @@ resource "aws_ram_principal_association" "tgw" {
 resource "aws_ec2_transit_gateway_route_table" "tgw_attachments" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
+  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
 
   transit_gateway_id = aws_ec2_transit_gateway.tgw.id
 }
@@ -74,7 +74,7 @@ resource "aws_ec2_transit_gateway_route_table" "tgw_attachments" {
 resource "aws_ec2_transit_gateway_route" "sharedservices_routes" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
+  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
 
   destination_cidr_block         = aws_vpc.the_vpc.cidr_block
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.tgw.id


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds Transit Gateway support for the User Services account.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
We want the User Services account to be able to route data through the Shared Services Transit Gateway.  In order to accomplish that, we create the resources specified in this PR.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
These changes were successfully applied in Staging.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
