### PR TITLE
Add role to read this repo's Terraform state

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ At this point the `ProvisionNetworking` policy is attached to the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| assume_read_terraform_state_policy_description | The description to associate with the IAM policy that allows assumption of the role that allows read-only access to Terraform state for cool-sharedservices-networking. | `string` | `Allow assumption of the ReadSharedServicesNetworkingTerraformState role in the Terraform account.` | no |
+| assume_read_terraform_state_policy_name | The name to assign the IAM policy that allows assumption of the role that allows read-only access to Terraform state for cool-sharedservices-networking. | `string` | `AssumeReadSharedServicesNetworkingTerraformState` | no |
 | aws_region | The AWS region where the shared services account is to be created (e.g. "us-east-1"). | `string` | `us-east-1` | no |
 | cool_cidr_block | The overall CIDR block associated with the COOL (e.g. "10.128.0.0/9"). | `string` | n/a | yes |
 | cool_domain | The domain where the COOL resources reside (e.g. "cool.cyber.dhs.gov"). | `string` | n/a | yes |
@@ -59,6 +61,8 @@ At this point the `ProvisionNetworking` policy is attached to the
 | provisionprivatednsrecords_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision DNS records in private zones in the Shared Services account. | `string` | `Allows sufficient permissions to provision DNS records in private zones in the Shared Services account.` | no |
 | provisionprivatednsrecords_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision DNS records in private zones in the Shared Services account. | `string` | `ProvisionPrivateDNSRecords` | no |
 | public_subnet_cidr_blocks | The CIDR blocks corresponding to the public subnets to be associated with the VPC (e.g. ["10.10.0.0/24", "10.10.1.0/24"]).  These must be /24 blocks, since we are using them to create reverse DNS zones.  This list must be the same length as private_subnet_cidr_blocks, since each private subnet will be assigned a NAT gateway in a public subnet in the same Availability Zone. | `list(string)` | n/a | yes |
+| read_terraform_state_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the cool-sharedservices-networking state in the S3 bucket where Terraform state is stored. | `string` | `Allows read-only access to the cool-sharedservices-networking state in the S3 bucket where Terraform state is stored.` | no |
+| read_terraform_state_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the cool-sharedservices-networking state in the S3 bucket where Terraform state is stored. | `string` | `ReadSharedServicesNetworkingTerraformState` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 | transit_gateway_description | The description to associate with the Transit Gateway in the Shared Services account that allows cross-VPC communication. | `string` | `The Transit Gateway in the Shared Services account that allows cross-VPC communication.` | no |
 | vpc_cidr_block | The overall CIDR block to be associated with the VPC (e.g. "10.10.0.0/16"). | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ At this point the `ProvisionNetworking` policy is attached to the
 | aws | ~> 3.0 |
 | aws.organizationsreadonly | ~> 3.0 |
 | aws.sharedservicesprovisionaccount | ~> 3.0 |
+| aws.terraformprovisionaccount | ~> 3.0 |
+| aws.users | ~> 3.0 |
 | terraform | n/a |
 
 ## Inputs ##

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 
 | Name | Description |
 |------|-------------|
+| assume_read_terraform_state_role_policy | The policy that allows assumption of the role that allows read-only access to the cool-sharedservices-networking state in the Terraform state bucket. |
 | default_route_table | The default route table for the VPC, which is used by the public subnets. |
 | private_route_tables | The route tables used by the private subnets in the VPC. |
 | private_subnet_nat_gws | The NAT gateways used in the private subnets in the VPC. |
@@ -80,6 +81,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 | provision_private_dns_records_role | The role that can provision DNS records in the private Route53 zone for the VPC. |
 | public_subnet_private_reverse_zones | The private Route53 reverse zones for the public subnets in the VPC. |
 | public_subnets | The public subnets in the VPC. |
+| read_terraform_state_role | The role that allows read-only access to the cool-sharedservices-networking state in the Terraform state bucket. |
 | transit_gateway | The Transit Gateway that allows cross-VPC communication. |
 | transit_gateway_attachment_route_tables | Transit Gateway route tables for each of the accounts that are allowed to attach to the Transit Gateway.  These route tables ensure that these accounts can communicate with the Shared Services account but are isolated from each other. |
 | transit_gateway_principal_associations | The RAM resource principal associations for the Transit Gateway that allows cross-VPC communication. |

--- a/assume_read_terraform_state_role.tf
+++ b/assume_read_terraform_state_role.tf
@@ -1,0 +1,22 @@
+# IAM policy document that allows assumption of the role in the Terraform
+# account that allows read-only access to the cool-sharedservices-networking
+# Terraform state.
+data "aws_iam_policy_document" "assume_read_terraform_state_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    resources = [
+      aws_iam_role.read_terraform_state.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "assume_read_terraform_state_role" {
+  provider = aws.users
+
+  description = var.assume_read_terraform_state_policy_description
+  name        = var.assume_read_terraform_state_policy_name
+  policy      = data.aws_iam_policy_document.assume_read_terraform_state_doc.json
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "assume_read_terraform_state_role_policy" {
+  value       = aws_iam_policy.assume_read_terraform_state_role
+  description = "The policy that allows assumption of the role that allows read-only access to the cool-sharedservices-networking state in the Terraform state bucket."
+}
+
 output "default_route_table" {
   value       = aws_default_route_table.public
   description = "The default route table for the VPC, which is used by the public subnets."
@@ -41,6 +46,11 @@ output "public_subnet_private_reverse_zones" {
 output "public_subnets" {
   value       = module.public.subnets
   description = "The public subnets in the VPC."
+}
+
+output "read_terraform_state_role" {
+  value       = aws_iam_role.read_terraform_state
+  description = "The role that allows read-only access to the cool-sharedservices-networking state in the Terraform state bucket."
 }
 
 output "transit_gateway" {

--- a/providers.tf
+++ b/providers.tf
@@ -6,6 +6,16 @@ provider "aws" {
   region = var.aws_region
 }
 
+# The provider used to lookup account IDs.  See locals.
+provider "aws" {
+  alias  = "organizationsreadonly"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.master.outputs.organizationsreadonly_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
 # The provider used to create resources inside the Shared Services account.
 provider "aws" {
   alias  = "sharedservicesprovisionaccount"
@@ -16,12 +26,22 @@ provider "aws" {
   }
 }
 
-# The provider used to lookup account IDs.  See locals.
+# The provider used to create resources inside the Terraform account.
 provider "aws" {
-  alias  = "organizationsreadonly"
+  alias  = "terraformprovisionaccount"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.master.outputs.organizationsreadonly_role.arn
+    role_arn     = data.terraform_remote_state.terraform.outputs.provisionaccount_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
+# The provider used to create resources inside the Users account.
+provider "aws" {
+  alias  = "users"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.users.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
 }

--- a/read_terraform_state_policy.tf
+++ b/read_terraform_state_policy.tf
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows read-only access to the
+# cool-sharedservices-networking Terraform state in the S3 bucket where
+# Terraform remote state is stored.  This is useful for cases when read-only
+# access to that state is needed, but read-only access to other Terraform
+# states in the bucket is not.
+# ------------------------------------------------------------------------------
+
+# IAM policy document that allows read-only access to the
+# cool-sharedservices-networking state in the Terraform state bucket.
+data "aws_iam_policy_document" "read_terraform_state" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      data.terraform_remote_state.terraform.outputs.state_bucket.arn,
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${data.terraform_remote_state.terraform.outputs.state_bucket.arn}/env:/*/cool-sharedservices-networking/*",
+    ]
+  }
+}
+
+# IAM policy for read-only access to cool-sharedservices-networking
+# Terraform state
+resource "aws_iam_policy" "read_terraform_state" {
+  provider = aws.terraformprovisionaccount
+
+  description = var.read_terraform_state_role_description
+  name        = var.read_terraform_state_role_name
+  policy      = data.aws_iam_policy_document.read_terraform_state.json
+}

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows read-only access to the
+# cool-sharedservices-networking state in the Terraform state bucket.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "read_terraform_state" {
+  provider = aws.terraformprovisionaccount
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.read_terraform_state_role_description
+  name               = var.read_terraform_state_role_name
+  tags               = var.tags
+}
+
+# Attach the IAM policy to the role
+resource "aws_iam_role_policy_attachment" "read_terraform_state" {
+  provider = aws.terraformprovisionaccount
+
+  policy_arn = aws_iam_policy.read_terraform_state.arn
+  role       = aws_iam_role.read_terraform_state.name
+}

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -16,6 +16,8 @@ data "terraform_remote_state" "master" {
     key            = "cool-accounts/master.tfstate"
   }
 
+  # There is only one environment for this account, so there is
+  # no need to match the current Terraform workspace.
   workspace = "production"
 }
 
@@ -32,4 +34,38 @@ data "terraform_remote_state" "sharedservices" {
   }
 
   workspace = terraform.workspace
+}
+
+data "terraform_remote_state" "terraform" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-accounts/terraform.tfstate"
+  }
+
+  # There is only one environment for this account, so there is
+  # no need to match the current Terraform workspace.
+  workspace = "production"
+}
+
+data "terraform_remote_state" "users" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-accounts/users.tfstate"
+  }
+
+  # There is only one environment for this account, so there is
+  # no need to match the current Terraform workspace.
+  workspace = "production"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,18 @@ variable "vpc_cidr_block" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "assume_read_terraform_state_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM policy that allows assumption of the role that allows read-only access to Terraform state for cool-sharedservices-networking."
+  default     = "Allow assumption of the ReadSharedServicesNetworkingTerraformState role in the Terraform account."
+}
+
+variable "assume_read_terraform_state_policy_name" {
+  type        = string
+  description = "The name to assign the IAM policy that allows assumption of the role that allows read-only access to Terraform state for cool-sharedservices-networking."
+  default     = "AssumeReadSharedServicesNetworkingTerraformState"
+}
+
 variable "aws_region" {
   type        = string
   description = "The AWS region where the shared services account is to be created (e.g. \"us-east-1\")."
@@ -69,6 +81,18 @@ variable "provisionprivatednsrecords_role_name" {
   type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows sufficient permissions to provision DNS records in private zones in the Shared Services account."
   default     = "ProvisionPrivateDNSRecords"
+}
+
+variable "read_terraform_state_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the cool-sharedservices-networking state in the S3 bucket where Terraform state is stored."
+  default     = "Allows read-only access to the cool-sharedservices-networking state in the S3 bucket where Terraform state is stored."
+}
+
+variable "read_terraform_state_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the cool-sharedservices-networking state in the S3 bucket where Terraform state is stored."
+  default     = "ReadSharedServicesNetworkingTerraformState"
 }
 
 variable "tags" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR creates a role that allows read-only access to the shared Terraform state for this repository, which resides in our S3 bucket in the Terraform account).

It also creates a policy in the Users account that allows the role above to be assumed.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
This read-only role previously existed in [`cisagov/cool-pca-transitgateway-attachment`](https://github.com/cisagov/cool-pca-transitgateway-attachment), but it was removed in https://github.com/cisagov/cool-pca-transitgateway-attachment/pull/5.

The role was moved so that it could reside in a more appropriate location and then be used by any other downstream repositories that require read-only access to this Terraform state.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was successfully Terraformed in Staging. All pre-commit hooks pass.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.

## ✅ Post-Merge Checklist ##
* [x] Apply changes to Production workspace.