### PR TITLE
Make Transit Gateway support Domain Manager accounts

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -45,6 +45,13 @@ locals {
   # example, "Shared Services (Production)".
   sharedservices_account_type = length(regexall("\\(([^()]*)\\)", local.sharedservices_account_name)) == 1 ? regex("\\(([^()]*)\\)", local.sharedservices_account_name)[0] : "Unknown"
 
+  # Determine the Domain Manager account of the same type
+  domainmanager_account_same_type = {
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id => account.name
+    if length(regexall("Domain Manager \\((${local.sharedservices_account_type})\\)", account.name)) > 0
+  }
+
   # Determine the env* accounts of the same type
   env_accounts_same_type = {
     for account in data.aws_organizations_organization.cool.accounts :

--- a/transitgateway.tf
+++ b/transitgateway.tf
@@ -44,13 +44,13 @@ resource "aws_ram_resource_association" "tgw" {
 }
 
 #
-# Share the resource with the other accounts that are allowed to
-# access it (currently the env*, PCA, and User Services accounts).
+# Share the resource with the other accounts that are allowed to access
+# it (currently the Domain Manger, env*, PCA, and User Services accounts).
 #
 resource "aws_ram_principal_association" "tgw" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
+  for_each = merge(local.domainmanager_account_same_type, local.env_accounts_same_type, local.pca_account_same_type, local.userservices_account_same_type)
 
   principal          = each.key
   resource_share_arn = aws_ram_resource_share.tgw.id
@@ -68,7 +68,7 @@ resource "aws_ram_principal_association" "tgw" {
 resource "aws_ec2_transit_gateway_route_table" "tgw_attachments" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
+  for_each = merge(local.domainmanager_account_same_type, local.env_accounts_same_type, local.pca_account_same_type)
 
   transit_gateway_id = aws_ec2_transit_gateway.tgw.id
 }
@@ -76,7 +76,7 @@ resource "aws_ec2_transit_gateway_route_table" "tgw_attachments" {
 resource "aws_ec2_transit_gateway_route" "sharedservices_routes" {
   provider = aws.sharedservicesprovisionaccount
 
-  for_each = merge(local.env_accounts_same_type, local.pca_account_same_type)
+  for_each = merge(local.domainmanager_account_same_type, local.env_accounts_same_type, local.pca_account_same_type)
 
   destination_cidr_block         = aws_vpc.the_vpc.cidr_block
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.tgw.id


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the newly-created Domain Manager accounts to the list of those accounts that are allowed to access our Transit Gateway.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Without this, the Domain Manager accounts would not be able to be included in the COOL network.

This work is part of https://github.com/cisagov/cool-system/issues/114.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I applied this change in the Shared Services (Staging) environment and verified that the expected Transit Gateway resources were created for the Domain Manager (Staging) account.

Further testing will be conducted with @zenine07 to confirm that Domain Manager is able to successfully route traffic through the Transit Gateway.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.

## ✅  Post-Merge Checklist ##
* [x] Apply Terraform in Production workspace
