### PR TITLE
Add VPC DHCP options that specify the default domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ At this point the `ProvisionNetworking` policy is attached to the
 | transit_gateway_principal_associations | The RAM resource principal associations for the Transit Gateway that allows cross-VPC communication. |
 | transit_gateway_ram_resource | The RAM resource share associated with the Transit Gateway that allows cross-VPC communication. |
 | transit_gateway_sharedservices_vpc_attachment | The Transit Gateway attachment to the Shared Services VPC. |
-| vpc | The shared services VPC. |
+| vpc | The Shared Services VPC. |
+| vpc_dhcp_options | The DHCP options for the Shared Services VPC. |
+| vpc_dhcp_options_association | The DHCP options association for the Shared Services VPC. |
 
 ## Notes ##
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -80,5 +80,15 @@ output "transit_gateway_sharedservices_vpc_attachment" {
 
 output "vpc" {
   value       = aws_vpc.the_vpc
-  description = "The shared services VPC."
+  description = "The Shared Services VPC."
+}
+
+output "vpc_dhcp_options" {
+  value       = aws_vpc_dhcp_options.the_dhcp_options
+  description = "The DHCP options for the Shared Services VPC."
+}
+
+output "vpc_dhcp_options_association" {
+  value       = aws_vpc_dhcp_options_association.the_dhcp_options_association
+  description = "The DHCP options association for the Shared Services VPC."
 }

--- a/provisionnetworking_policy.tf
+++ b/provisionnetworking_policy.tf
@@ -7,8 +7,10 @@ data "aws_iam_policy_document" "provisionnetworking_policy_doc" {
   statement {
     actions = [
       "ec2:AllocateAddress",
+      "ec2:AssociateDhcpOptions",
       "ec2:AssociateRouteTable",
       "ec2:AttachInternetGateway",
+      "ec2:CreateDhcpOptions",
       "ec2:CreateFlowLogs",
       "ec2:CreateInternetGateway",
       "ec2:CreateNatGateway",
@@ -23,6 +25,7 @@ data "aws_iam_policy_document" "provisionnetworking_policy_doc" {
       "ec2:CreateTransitGatewayRouteTable",
       "ec2:CreateTransitGatewayVpcAttachment",
       "ec2:CreateVpc",
+      "ec2:DeleteDhcpOptions",
       "ec2:DeleteInternetGateway",
       "ec2:DeleteNatGateway",
       "ec2:DeleteNetworkAcl",

--- a/vpc.tf
+++ b/vpc.tf
@@ -19,6 +19,23 @@ resource "aws_vpc" "the_vpc" {
   tags                 = var.tags
 }
 
+# DHCP options for instances that run in the Shared Services VPC
+resource "aws_vpc_dhcp_options" "the_dhcp_options" {
+  provider = aws.sharedservicesprovisionaccount
+
+  domain_name         = var.cool_domain
+  domain_name_servers = ["AmazonProvidedDNS"]
+  tags                = var.tags
+}
+
+# Associate the DHCP options with the Shared Services VPC
+resource "aws_vpc_dhcp_options_association" "the_dhcp_options_association" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id          = aws_vpc.the_vpc.id
+  dhcp_options_id = aws_vpc_dhcp_options.the_dhcp_options.id
+}
+
 # The internet gateway for the VPC
 resource "aws_internet_gateway" "the_igw" {
   provider = aws.sharedservicesprovisionaccount


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds VPC DHCP options that specify the COOL domain as the default domain.  It also adds the appropriate permissions so that we can create and destroy these DHCP options, as well as associate these DHCP options with the VPC.

## 💭 Motivation and context ##

This change isn't really required, but it is convenient.  Before this change hosts such as `ipa0` had to be specified as FQDNs, e.g. `ipa.staging.cool.cyber.dhs.gov`.  Now a simple `ipa0` will suffice.

## 🧪 Testing ##

All `pre-commit` hooks pass, and I applied these changes to our COOL staging environment and verified that they worked as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
