### PR TITLE
Add the overall COOL CIDR block as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 
 | Name | Description |
 |------|-------------|
+| cool\_cidr\_block | The overall CIDR block associated with the COOL. |
 | default\_route\_table | The default route table for the VPC, which is used by the public subnets. |
 | private\_route\_tables | The route tables used by the private subnets in the VPC. |
 | private\_subnet\_nat\_gws | The NAT gateways used in the private subnets in the VPC. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "cool_cidr_block" {
+  value       = var.cool_cidr_block
+  description = "The overall CIDR block associated with the COOL."
+}
+
 output "default_route_table" {
   value       = aws_default_route_table.public
   description = "The default route table for the VPC, which is used by the public subnets."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the overall COOL CIDR block as an output.

## 💭 Motivation and context ##

This information is useful for me to have in cisagov/cool-sharedservices-openvpn#??.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
