### PR TITLE
Create a security group for S3 VPC endpoint clients

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 | private | github.com/cisagov/distributed-subnets-tf-module | n/a |
 | public | github.com/cisagov/distributed-subnets-tf-module | n/a |
 | read\_terraform\_state | github.com/cisagov/terraform-state-read-role-tf-module | n/a |
-| vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | >=2.0.0, <2.1.0 |
+| vpc\_flow\_logs | trussworks/vpc-flow-logs/aws | ~>2.0 |
 
 ## Resources ##
 
@@ -83,6 +83,8 @@ At this point the `ProvisionNetworking` policy is attached to the
 | [aws_route53_zone.public_subnet_private_reverse_zones](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route_table.private_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.private_route_table_associations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_security_group.s3_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.egress_to_s3_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_vpc.the_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.the_dhcp_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.the_dhcp_options_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
@@ -134,6 +136,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 | public\_subnet\_private\_reverse\_zones | The private Route53 reverse zones for the public subnets in the VPC. |
 | public\_subnets | The public subnets in the VPC. |
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-sharedservices-networking state in the Terraform state bucket. |
+| s3\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the S3 VPC endpoint. |
 | transit\_gateway | The Transit Gateway that allows cross-VPC communication. |
 | transit\_gateway\_attachment\_route\_tables | Transit Gateway route tables for each of the accounts that are allowed to attach to the Transit Gateway.  These route tables ensure that these accounts can communicate with the Shared Services account but are isolated from each other. |
 | transit\_gateway\_principal\_associations | The RAM resource principal associations for the Transit Gateway that allows cross-VPC communication. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,6 +53,11 @@ output "read_terraform_state" {
   description = "The IAM policies and role that allow read-only access to the cool-sharedservices-networking state in the Terraform state bucket."
 }
 
+output "s3_endpoint_client_security_group" {
+  value       = aws_security_group.s3_endpoint_client
+  description = "A security group for any instances that wish to communicate with the S3 VPC endpoint."
+}
+
 output "transit_gateway" {
   value       = aws_ec2_transit_gateway.tgw
   description = "The Transit Gateway that allows cross-VPC communication."

--- a/s3_endpoint_client_sg.tf
+++ b/s3_endpoint_client_sg.tf
@@ -1,0 +1,22 @@
+# Security group for instances that use the S3 VPC endpoint
+resource "aws_security_group" "s3_endpoint_client" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "S3 endpoint client"
+  }
+}
+
+# Allow egress via HTTPS to the S3 gateway endpoint.
+resource "aws_security_group_rule" "egress_to_s3_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id = aws_security_group.s3_endpoint_client.id
+  type              = "egress"
+  protocol          = "tcp"
+  prefix_list_ids   = [aws_vpc_endpoint.s3.prefix_list_id]
+  from_port         = 443
+  to_port           = 443
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Creates a security group that can be applied to any EC2 instances in the Shared Services VPC that need to use the S3 VPC endpoint
- Adds this new security group to the outputs

See also:
- cisagov/cool-sharedservices-openvpn#60

## 💭 Motivation and context ##

Using an SG in this way matches the paradigm used in [cisagov/cool-assessment-terraform](https://github.com/cisagov/cool-assessment-terraform), where individual SGs are used for each "facet" of an EC2 instance's network access.

## 🧪 Testing ##

I applied these changes as well as those from cisagov/cool-sharedservices-openvpn#60 to our COOL staging environment and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.