### PR TITLE
Add many more types of VPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,50 @@ At this point the `ProvisionNetworking` policy is attached to the
 | [aws_route53_zone.public_subnet_private_reverse_zones](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route_table.private_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.private_route_table_associations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_security_group.cloudwatch_agent_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.cloudwatch_agent_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.ec2_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.ec2_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.s3_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.ssm_agent_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.ssm_agent_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.ssm_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.ssm_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.sts_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.sts_endpoint_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.egress_from_cloudwatch_agent_endpoint_client_to_cloudwatch_agent_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_from_ec2_endpoint_client_to_ec2_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_from_ssm_agent_endpoint_client_to_ssm_agent_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_from_ssm_endpoint_client_to_ssm_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_from_sts_endpoint_client_to_sts_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_to_s3_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_cloudwatch_agent_endpoint_client_to_cloudwatch_agent_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_ec2_endpoint_client_to_ec2_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_ssm_agent_endpoint_client_to_ssm_agent_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_ssm_endpoint_client_to_ssm_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_from_sts_endpoint_client_to_sts_endpoint_via_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_vpc.the_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.the_dhcp_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.the_dhcp_options_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_dhcp_options_association) | resource |
+| [aws_vpc_endpoint.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ec2messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ssmmessages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint_route_table_association.s3_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
 | [aws_vpc_endpoint_route_table_association.s3_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
+| [aws_vpc_endpoint_subnet_association.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.ec2messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.ssmmessages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.sharedservices](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -125,8 +161,10 @@ At this point the `ProvisionNetworking` policy is attached to the
 
 | Name | Description |
 |------|-------------|
+| cloudwatch\_agent\_endpoint\_client\_security\_group | A security group for any instances that run the AWS CloudWatch agent.  This security groups allows such instances to communicate with the VPC endpoints that are required by the AWS CloudWatch agent. |
 | cool\_cidr\_block | The overall CIDR block associated with the COOL. |
 | default\_route\_table | The default route table for the VPC, which is used by the public subnets. |
+| ec2\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the EC2 VPC endpoint. |
 | private\_route\_tables | The route tables used by the private subnets in the VPC. |
 | private\_subnet\_nat\_gws | The NAT gateways used in the private subnets in the VPC. |
 | private\_subnet\_private\_reverse\_zones | The private Route53 reverse zones for the private subnets in the VPC. |
@@ -137,6 +175,9 @@ At this point the `ProvisionNetworking` policy is attached to the
 | public\_subnets | The public subnets in the VPC. |
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-sharedservices-networking state in the Terraform state bucket. |
 | s3\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the S3 VPC endpoint. |
+| ssm\_agent\_endpoint\_client\_security\_group | A security group for any instances that run the AWS SSM agent.  This security group allows such instances to communicate with the VPC endpoints that are required by the AWS SSM agent. |
+| ssm\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the SSM VPC endpoint. |
+| sts\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the STS VPC endpoint. |
 | transit\_gateway | The Transit Gateway that allows cross-VPC communication. |
 | transit\_gateway\_attachment\_route\_tables | Transit Gateway route tables for each of the accounts that are allowed to attach to the Transit Gateway.  These route tables ensure that these accounts can communicate with the Shared Services account but are isolated from each other. |
 | transit\_gateway\_principal\_associations | The RAM resource principal associations for the Transit Gateway that allows cross-VPC communication. |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ At this point the `ProvisionNetworking` policy is attached to the
 
 | Name | Description |
 |------|-------------|
-| cloudwatch\_agent\_endpoint\_client\_security\_group | A security group for any instances that run the AWS CloudWatch agent.  This security groups allows such instances to communicate with the VPC endpoints that are required by the AWS CloudWatch agent. |
+| cloudwatch\_agent\_endpoint\_client\_security\_group | A security group for any instances that run the AWS CloudWatch agent.  This security group allows such instances to communicate with the VPC endpoints that are required by the AWS CloudWatch agent. |
 | cool\_cidr\_block | The overall CIDR block associated with the COOL. |
 | default\_route\_table | The default route table for the VPC, which is used by the public subnets. |
 | ec2\_endpoint\_client\_security\_group | A security group for any instances that wish to communicate with the EC2 VPC endpoint. |

--- a/cloudwatch_agent_endpoint_client_sg.tf
+++ b/cloudwatch_agent_endpoint_client_sg.tf
@@ -1,0 +1,23 @@
+# Security group for instances that use CloudWatch
+resource "aws_security_group" "cloudwatch_agent_endpoint_client" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "CloudWatch agent endpoint client"
+  }
+}
+
+# Allow egress via HTTPS to the CloudWatch agent endpoint security
+# group.
+resource "aws_security_group_rule" "egress_from_cloudwatch_agent_endpoint_client_to_cloudwatch_agent_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.cloudwatch_agent_endpoint_client.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.cloudwatch_agent_endpoint.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/cloudwatch_agent_endpoint_sg.tf
+++ b/cloudwatch_agent_endpoint_sg.tf
@@ -1,0 +1,24 @@
+# Security group for the interface endpoints used by the CloudWatch
+# agent in the private subnet
+resource "aws_security_group" "cloudwatch_agent_endpoint" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "CloudWatch agent endpoints"
+  }
+}
+
+# Allow ingress via HTTPS from the CloudWatch agent endpoint client
+# security group.
+resource "aws_security_group_rule" "ingress_from_cloudwatch_agent_endpoint_client_to_cloudwatch_agent_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.cloudwatch_agent_endpoint.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.cloudwatch_agent_endpoint_client.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/ec2_endpoint_client_sg.tf
+++ b/ec2_endpoint_client_sg.tf
@@ -1,0 +1,22 @@
+# Security group for instances that use the EC2 VPC endpoint
+resource "aws_security_group" "ec2_endpoint_client" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "EC2 endpoint client"
+  }
+}
+
+# Allow egress via HTTPS to the EC2 endpoint security group.
+resource "aws_security_group_rule" "egress_from_ec2_endpoint_client_to_ec2_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.ec2_endpoint_client.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ec2_endpoint.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/ec2_endpoint_sg.tf
+++ b/ec2_endpoint_sg.tf
@@ -1,0 +1,22 @@
+# Security group for the EC2 interface endpoint in the private subnet
+resource "aws_security_group" "ec2_endpoint" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "EC2 endpoint"
+  }
+}
+
+# Allow ingress via HTTPS from the EC2 endpoint client security group
+resource "aws_security_group_rule" "ingress_from_ec2_endpoint_client_to_ec2_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.ec2_endpoint.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ec2_endpoint_client.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "cloudwatch_agent_endpoint_client_security_group" {
+  value       = aws_security_group.cloudwatch_agent_endpoint_client
+  description = "A security group for any instances that run the AWS CloudWatch agent.  This security groups allows such instances to communicate with the VPC endpoints that are required by the AWS CloudWatch agent."
+}
+
 output "cool_cidr_block" {
   value       = var.cool_cidr_block
   description = "The overall CIDR block associated with the COOL."
@@ -6,6 +11,11 @@ output "cool_cidr_block" {
 output "default_route_table" {
   value       = aws_default_route_table.public
   description = "The default route table for the VPC, which is used by the public subnets."
+}
+
+output "ec2_endpoint_client_security_group" {
+  value       = aws_security_group.ec2_endpoint_client
+  description = "A security group for any instances that wish to communicate with the EC2 VPC endpoint."
 }
 
 output "private_route_tables" {
@@ -56,6 +66,21 @@ output "read_terraform_state" {
 output "s3_endpoint_client_security_group" {
   value       = aws_security_group.s3_endpoint_client
   description = "A security group for any instances that wish to communicate with the S3 VPC endpoint."
+}
+
+output "ssm_agent_endpoint_client_security_group" {
+  value       = aws_security_group.ssm_agent_endpoint_client
+  description = "A security group for any instances that run the AWS SSM agent.  This security group allows such instances to communicate with the VPC endpoints that are required by the AWS SSM agent."
+}
+
+output "ssm_endpoint_client_security_group" {
+  value       = aws_security_group.ssm_endpoint_client
+  description = "A security group for any instances that wish to communicate with the SSM VPC endpoint."
+}
+
+output "sts_endpoint_client_security_group" {
+  value       = aws_security_group.sts_endpoint_client
+  description = "A security group for any instances that wish to communicate with the STS VPC endpoint."
 }
 
 output "transit_gateway" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "cloudwatch_agent_endpoint_client_security_group" {
   value       = aws_security_group.cloudwatch_agent_endpoint_client
-  description = "A security group for any instances that run the AWS CloudWatch agent.  This security groups allows such instances to communicate with the VPC endpoints that are required by the AWS CloudWatch agent."
+  description = "A security group for any instances that run the AWS CloudWatch agent.  This security group allows such instances to communicate with the VPC endpoints that are required by the AWS CloudWatch agent."
 }
 
 output "cool_cidr_block" {

--- a/ssm_agent_endpoint_client_sg.tf
+++ b/ssm_agent_endpoint_client_sg.tf
@@ -1,0 +1,22 @@
+# Security group for instances that use the SSM agent
+resource "aws_security_group" "ssm_agent_endpoint_client" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "SSM agent endpoint client"
+  }
+}
+
+# Allow egress via HTTPS to the SSM agent endpoint security group.
+resource "aws_security_group_rule" "egress_from_ssm_agent_endpoint_client_to_ssm_agent_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.ssm_agent_endpoint_client.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ssm_agent_endpoint.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/ssm_agent_endpoint_sg.tf
+++ b/ssm_agent_endpoint_sg.tf
@@ -1,0 +1,23 @@
+# Security group for the VPC interface endpoints in the private subnet
+# that are required by the SSM agent
+resource "aws_security_group" "ssm_agent_endpoint" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "SSM agent endpoints"
+  }
+}
+
+# Allow ingress via HTTPS from the SSM endpoint agent client security group.
+resource "aws_security_group_rule" "ingress_from_ssm_agent_endpoint_client_to_ssm_agent_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.ssm_agent_endpoint.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ssm_agent_endpoint_client.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/ssm_endpoint_client_sg.tf
+++ b/ssm_endpoint_client_sg.tf
@@ -1,0 +1,22 @@
+# Security group for instances that use the SSM VPC endpoints
+resource "aws_security_group" "ssm_endpoint_client" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "SSM endpoint client"
+  }
+}
+
+# Allow egress via HTTPS to the SSM endpoint security group.
+resource "aws_security_group_rule" "egress_from_ssm_endpoint_client_to_ssm_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.ssm_endpoint_client.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ssm_endpoint.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/ssm_endpoint_sg.tf
+++ b/ssm_endpoint_sg.tf
@@ -1,0 +1,23 @@
+# Security group for the SSM interface endpoint (and other endpoints
+# required when using the SSM service) in the private subnet
+resource "aws_security_group" "ssm_endpoint" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "SSM endpoints"
+  }
+}
+
+# Allow ingress via HTTPS from the SSM endpoint client security group.
+resource "aws_security_group_rule" "ingress_from_ssm_endpoint_client_to_ssm_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.ssm_endpoint.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ssm_endpoint_client.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/ssm_endpoint_sg.tf
+++ b/ssm_endpoint_sg.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "ssm_endpoint" {
   vpc_id = aws_vpc.the_vpc.id
 
   tags = {
-    Name = "SSM endpoints"
+    Name = "SSM endpoint"
   }
 }
 

--- a/ssm_endpoint_sg.tf
+++ b/ssm_endpoint_sg.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "ssm_endpoint" {
   vpc_id = aws_vpc.the_vpc.id
 
   tags = {
-    Name = "SSM endpoint"
+    Name = "SSM endpoints"
   }
 }
 

--- a/sts_endpoint_client_sg.tf
+++ b/sts_endpoint_client_sg.tf
@@ -1,0 +1,22 @@
+# Security group for instances that use the STS VPC endpoint
+resource "aws_security_group" "sts_endpoint_client" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "STS endpoint client"
+  }
+}
+
+# Allow egress via HTTPS from the STS endpoint security group.
+resource "aws_security_group_rule" "egress_from_sts_endpoint_client_to_sts_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.sts_endpoint_client.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.sts_endpoint.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/sts_endpoint_client_sg.tf
+++ b/sts_endpoint_client_sg.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "sts_endpoint_client" {
   }
 }
 
-# Allow egress via HTTPS from the STS endpoint security group.
+# Allow egress via HTTPS to the STS endpoint security group.
 resource "aws_security_group_rule" "egress_from_sts_endpoint_client_to_sts_endpoint_via_https" {
   provider = aws.sharedservicesprovisionaccount
 

--- a/sts_endpoint_sg.tf
+++ b/sts_endpoint_sg.tf
@@ -1,0 +1,22 @@
+# Security group for the STS interface endpoint
+resource "aws_security_group" "sts_endpoint" {
+  provider = aws.sharedservicesprovisionaccount
+
+  vpc_id = aws_vpc.the_vpc.id
+
+  tags = {
+    Name = "STS endpoint"
+  }
+}
+
+# Allow ingress via HTTPS from the STS endpoint client security group.
+resource "aws_security_group_rule" "ingress_from_sts_endpoint_client_to_sts_endpoint_via_https" {
+  provider = aws.sharedservicesprovisionaccount
+
+  security_group_id        = aws_security_group.sts_endpoint.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.sts_endpoint_client.id
+  from_port                = 443
+  to_port                  = 443
+}

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -122,14 +122,6 @@ resource "aws_vpc_endpoint_subnet_association" "sts" {
 # Note that SSM requires several other endpoints to function properly.
 # See here for more details:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html#sysman-setting-up-vpc-create
-resource "aws_vpc_endpoint_subnet_association" "ssm" {
-  provider = aws.sharedservicesprovisionaccount
-
-  for_each = toset(var.private_subnet_cidr_blocks)
-
-  subnet_id       = module.private.subnets[each.value].id
-  vpc_endpoint_id = aws_vpc_endpoint.ssm.id
-}
 resource "aws_vpc_endpoint_subnet_association" "ec2" {
   provider = aws.sharedservicesprovisionaccount
 
@@ -153,6 +145,14 @@ resource "aws_vpc_endpoint_subnet_association" "kms" {
 
   subnet_id       = module.private.subnets[each.value].id
   vpc_endpoint_id = aws_vpc_endpoint.kms.id
+}
+resource "aws_vpc_endpoint_subnet_association" "ssm" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.ssm.id
 }
 resource "aws_vpc_endpoint_subnet_association" "ssmmessages" {
   provider = aws.sharedservicesprovisionaccount

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -3,6 +3,186 @@
 #-------------------------------------------------------------------------------
 
 #
+# VPC interface endpoints
+#
+
+# STS interface endpoint
+resource "aws_vpc_endpoint" "sts" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.sts_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.sts"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+
+# Interface endpoints associated with the SSM agent
+resource "aws_vpc_endpoint" "ec2" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    # The CloudWatch agent reads a few pieces of data from the ec2
+    # endpoint.  You can see this by inspecting the AWS-provided
+    # CloudWatchAgentServerPolicyIAM policy.
+    aws_security_group.cloudwatch_agent_endpoint.id,
+    aws_security_group.ec2_endpoint.id,
+    aws_security_group.ssm_agent_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.ec2"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+resource "aws_vpc_endpoint" "ec2messages" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm_agent_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.ec2messages"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+resource "aws_vpc_endpoint" "kms" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm_agent_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.kms"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+resource "aws_vpc_endpoint" "ssm" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm_agent_endpoint.id,
+    aws_security_group.ssm_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.ssm"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+resource "aws_vpc_endpoint" "ssmmessages" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.ssm_agent_endpoint.id,
+    aws_security_group.ssm_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.ssmmessages"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+
+# Interface endpoints associated with the CloudWatch agent
+resource "aws_vpc_endpoint" "logs" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.cloudwatch_agent_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.logs"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+resource "aws_vpc_endpoint" "monitoring" {
+  provider = aws.sharedservicesprovisionaccount
+
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.cloudwatch_agent_endpoint.id,
+  ]
+  service_name      = "com.amazonaws.${var.aws_region}.monitoring"
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.the_vpc.id
+}
+
+# Associate the STS interface endpoint with the private subnets
+resource "aws_vpc_endpoint_subnet_association" "sts" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.sts.id
+}
+
+# Associate the SSM interface endpoints with the private subnets
+#
+# Note that SSM requires several other endpoints to function properly.
+# See here for more details:
+# https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-create-vpc.html#sysman-setting-up-vpc-create
+resource "aws_vpc_endpoint_subnet_association" "ssm" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.ssm.id
+}
+resource "aws_vpc_endpoint_subnet_association" "ec2" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.ec2.id
+}
+resource "aws_vpc_endpoint_subnet_association" "ec2messages" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.ec2messages.id
+}
+resource "aws_vpc_endpoint_subnet_association" "kms" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.kms.id
+}
+resource "aws_vpc_endpoint_subnet_association" "ssmmessages" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.ssmmessages.id
+}
+
+# Associate the CloudWatch agent interface endpoints with the private
+# subnets.
+resource "aws_vpc_endpoint_subnet_association" "logs" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.logs.id
+}
+resource "aws_vpc_endpoint_subnet_association" "monitoring" {
+  provider = aws.sharedservicesprovisionaccount
+
+  for_each = toset(var.private_subnet_cidr_blocks)
+
+  subnet_id       = module.private.subnets[each.value].id
+  vpc_endpoint_id = aws_vpc_endpoint.monitoring.id
+}
+
+#
 # VPC gateway endpoints
 #
 

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -25,7 +25,7 @@ resource "aws_vpc_endpoint" "ec2" {
 
   private_dns_enabled = true
   security_group_ids = [
-    # The CloudWatch agent reads a few pieces of data from the ec2
+    # The CloudWatch agent reads a few pieces of data from the EC2
     # endpoint.  You can see this by inspecting the AWS-provided
     # CloudWatchAgentServerPolicyIAM policy.
     aws_security_group.cloudwatch_agent_endpoint.id,


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds many more types of VPC endpoints.

## 💭 Motivation and context ##

There is no need for our AWS API traffic to go back out to the internet, and it improves 
security if it does not.

See also:
- cisagov/cool-sharedservices-freeipa#63
- cisagov/cool-sharedservices-openvpn#61

## 🧪 Testing ##

All automated tests pass.  I also applied these changes to our COOL staging environment and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.